### PR TITLE
Fixed 'An unexpected error occurred' for the sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ curl -d "request_host=test.com" \
 curl -d "name=oauth2" \
      -d "config.scopes=email, phone, address" \
      -d "config.mandatory_scope=true" \
+     -d "config.enable_authorization_code=true" \
      http://127.0.0.1:8001/apis/test.com/plugins/
 ```
 
@@ -144,9 +145,9 @@ To retrieve an `access_token` you can now execute the following request:
 ```shell
 curl https://127.0.0.1:8443/oauth2/token \
      -H "Host: test.com" \
-     -d "grant_type=authorization_code" \ 
-     -d "client_id=318f98be1453427bc2937fceab9811bd" \ 
+     -d "grant_type=authorization_code" \
+     -d "client_id=318f98be1453427bc2937fceab9811bd" \
      -d "client_secret=efbc9e1f2bcc4968c988ef5b839dd5a4" \
-     -d "redirect_uri=http://getkong.org/" \ 
+     -d "redirect_uri=http://getkong.org/" \
      -d "code=ad286cf6694d40aac06eff2797b7208d" --insecure
 ```

--- a/app.js
+++ b/app.js
@@ -1,6 +1,6 @@
 var request    = require('request');
 var url        = require('url');
-var bodyParser = require('body-parser')
+var bodyParser = require('body-parser');
 var express    = require("express");
 var app        = express();
 
@@ -11,7 +11,7 @@ app.use(bodyParser());
 process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
 
 function load_env_variable(name) {
-  var value = process.env[name]
+  var value = process.env[name];
   if (value) {
     console.log(name + " is " + value);
     return value;


### PR DESCRIPTION
The OAuth2 "Hello World" sample did not work with current Kong versions; apparently the `enable_authorization_code` setting defaulted to `true` at some point, but does not anymore.

This resulted in Kong returning `An unexpected error occurred.` when posting to the `/oauth2/authorize` endpoint; what you saw from this was simply that `app.js` crashed at line 87, not being able to parse that error string as JSON.

Other things contained in this PR:
- Added semicolons to make `jshint` happy
- Removed trailing spaces from the `curl` which creates the access tokens; on Mac OS X, these spaces lead to bash interpreting the backslashes as "escape", and not as the intended "continue" tokens.
