### PR TITLE
Feat/kong gelato demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ curl -d "name=oauth2" \
      -d "config.scopes=email, phone, address" \
      -d "config.mandatory_scope=true" \
      -d "config.enable_authorization_code=true" \
-     http://127.0.0.1:8001/apis/test.com/plugins/
+     -d "config.accept_http_if_already_terminated=true" \
+     http://127.0.0.1:8001/apis/cats/plugins/
 ```
 
 This will output a response including an auto-generated `provision_key` that we need to use later:

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ curl -d "name=oauth2" \
      -d "config.scopes=email, phone, address" \
      -d "config.mandatory_scope=true" \
      -d "config.enable_authorization_code=true" \
-     -d "config.accept_http_if_already_terminated=true" \
      http://127.0.0.1:8001/apis/cats/plugins/
 ```
 

--- a/README.md
+++ b/README.md
@@ -23,12 +23,13 @@ npm install
 
 To run this project, execute the following operations.
 
-* Make sure you have Kong >= 0.4.0 running. We assume Kong is running at `127.0.0.1` with the default ports.
+* Make sure you have Kong >= 0.10.3 running. We assume Kong is running at `127.0.0.1` with the default ports.
 
 * Let's add a simple test API:
 
 ```shell
-curl -d "request_host=test.com" \
+curl -d "name=cats" \
+     -d "uris=/cats" \
      -d "upstream_url=http://mockbin.org/" \
      http://127.0.0.1:8001/apis/
 ```
@@ -57,7 +58,7 @@ This will output a response including an auto-generated `provision_key` that we 
         "mandatory_scope": true,
         "provision_key": "2ef290c575cc46eec61947aa9f1e67d3",
         "hide_credentials": false,
-        "enable_implicit_grant": false,
+        "enable_authorization_code": true,
         "token_expiration": 7200
     },
     "created_at": 1435783325000,
@@ -100,23 +101,34 @@ That outputs the following response, including the `client_id` and `client_secre
 
 # Running the web application
 
-Now that Kong has all the data configured, we can start our application using the `provision_key` that has been returned when we added the plugin:
+Now that Kong has all the data configured, we can start our application using the `provision_key` that has been returned when we added the plugin.
+
+Export the environment variables used by the Node.js application:
 
 ```shell
-# Exporting some environment variables used by the Node.js application
 export PROVISION_KEY="2ef290c575cc46eec61947aa9f1e67d3"
 export KONG_ADMIN="http://127.0.0.1:8001"
 export KONG_API="https://127.0.0.1:8443"
-export API_PUBLIC_DNS="test.com"
+export API_PATH="/cats"
 export SCOPES="{ \
   \"email\": \"Grant permissions to read your email address\", \
   \"address\": \"Grant permissions to read your address information\", \
   \"phone\": \"Grant permissions to read your mobile phone number\" \
 }"
+```
 
-# Starting the node.js application
+Note: By default, the application listens on port 3000. You can modify this if you like:
+
+```shell
+export LISTEN_PORT=3301
+```
+
+Then, start the authorization server:
+
+```shell
 node app.js
 ```
+
 
 # Testing the Authorization Flow
 

--- a/app.js
+++ b/app.js
@@ -34,16 +34,21 @@ var KONG_ADMIN = load_env_variable("KONG_ADMIN");
 var KONG_API = load_env_variable("KONG_API");
 
 /*
-  The API Public DNS, required later when making a request
+  The path to the API, required later when making a request
   to authorize the OAuth 2.0 client application
 */
-var API_PUBLIC_DNS = load_env_variable("API_PUBLIC_DNS");
+var API_PATH = load_env_variable("API_PATH");
 
 /* 
   The scopes that we support, with their extended
   description for a nicer frontend user experience
 */
-var SCOPE_DESCRIPTIONS = JSON.parse(load_env_variable("SCOPES")); //The scopes that we support, with their extended
+var SCOPE_DESCRIPTIONS = JSON.parse(load_env_variable("SCOPES"));
+
+/* 
+  The port the authorization server listens on. Defaults to 3000.
+*/
+var LISTEN_PORT = process.env["LISTEN_PORT"] || 3000
 
 /*
   Retrieves the OAuth 2.0 client application name from
@@ -74,9 +79,8 @@ function get_application_name(client_id, callback) {
 function authorize(client_id, response_type, scope, callback) {
   request({
     method: "POST",
-    url: KONG_API + "/oauth2/authorize",
-    headers: { host: API_PUBLIC_DNS },
-    form: { 
+    url: KONG_API + API_PATH + "/oauth2/authorize",
+	  form: { 
       client_id: client_id, 
       response_type: response_type, 
       scope: scope, 
@@ -126,6 +130,6 @@ app.get("/", function(req, res) {
   res.render('index');
 });
 
-app.listen(3000);
+app.listen(LISTEN_PORT);
 
-console.log("Running at Port 3000");
+console.log("Running at Port " + LISTEN_PORT);


### PR DESCRIPTION
This PR makes changes to the sample authorization server so that it can be used in a guide about how to configure API docs in Gelato that are connected to Kong-managed APIs secured by the OAuth2 plugin.

* Upgrade to Kong 0.10 syntax for creating the sample API.
* Allow user to configure the port the server listens on (still defaults to 3000).
* Specify the API by URI rather than host. This is a workaround for a limitation in Gelato.
