### PR TITLE
Add docker-compose and fix typo in the instruction README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,14 @@ npm install
 
 To run this project, execute the following operations.
 
-* Make sure you have Kong >= 0.10.3 running. We assume Kong is running at `127.0.0.1` with the default ports.
+* Make sure you have Kong >= 0.10.3 running. We assume Kong is running at `127.0.0.1` with the default ports. One way to do it is using docker compose provided in `docker-compose.yml` and run the following
+
+```shell
+# needs to run sequentially due to migration
+docker-compose up kong_db
+docker-compose up kong_migration
+docker-compose up kong
+```
 
 * Let's add a simple test API:
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Done! Now the client application has a `code` that it can use later on to reques
 To retrieve an `access_token` you can now execute the following request:
 
 ```shell
-curl https://127.0.0.1:8443/oauth2/token \
+curl https://127.0.0.1:8443/cats/oauth2/token \
      -H "Host: test.com" \
      -d "grant_type=authorization_code" \
      -d "client_id=318f98be1453427bc2937fceab9811bd" \

--- a/README.md
+++ b/README.md
@@ -163,7 +163,6 @@ To retrieve an `access_token` you can now execute the following request:
 
 ```shell
 curl https://127.0.0.1:8443/cats/oauth2/token \
-     -H "Host: test.com" \
      -d "grant_type=authorization_code" \
      -d "client_id=318f98be1453427bc2937fceab9811bd" \
      -d "client_secret=efbc9e1f2bcc4968c988ef5b839dd5a4" \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,39 @@
+version: '3.4'
+services:
+  kong:
+    image: kong:0.11.2
+    restart: always
+    depends_on:
+      - kong_db
+    ports:
+      - 8000:8000
+      - 8443:8443
+      - 8001:8001
+    environment:
+      KONG_DATABASE: postgres
+      KONG_PG_USER: kong
+      KONG_PG_PASSWORD: kong
+      KONG_PG_DATABASE: kong
+      KONG_PG_HOST: kong_db
+      KONG_LOG_LEVEL: debug
+
+  kong_migration:
+    image: kong:0.11.2
+    depends_on:
+      - kong_db
+    environment:
+      KONG_DATABASE: postgres
+      KONG_PG_USER: kong
+      KONG_PG_PASSWORD: kong
+      KONG_PG_DATABASE: kong
+      KONG_PG_HOST: kong_db
+      KONG_LOG_LEVEL: debug
+    command: kong migrations up
+
+  kong_db:
+    image: postgres:9.4
+    environment:
+      POSTGRES_USER: kong
+      POSTGRES_DB: kong
+      POSTGRES_PASSWORD: kong
+


### PR DESCRIPTION
Add docker-compose and fix typo in the instruction README.md

Edit this

```diff
- curl https://127.0.0.1:8443/oauth2/token \
+ curl https://127.0.0.1:8443/cats/oauth2/token \
-     -H "Host: test.com" \
     -d "grant_type=authorization_code" \
     -d "client_id=318f98be1453427bc2937fceab9811bd" \
     -d "client_secret=efbc9e1f2bcc4968c988ef5b839dd5a4" \
     -d "redirect_uri=http://getkong.org/" \
     -d "code=ad286cf6694d40aac06eff2797b7208d" --insecure
```

and add docker-compose to make it easy to try