### PR TITLE
Update README.md and app.js to work with /services and /routes instead of /apis - Kong CE 0.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,11 +170,13 @@ Done! Now the client application has a `code` that it can use later on to reques
 To retrieve an `access_token` you can now execute the following request:
 
 ```shell
-curl https://127.0.0.1:8443/oauth2/token \
-     -H "Host: test.com" \
-     -d "grant_type=authorization_code" \
-     -d "client_id=318f98be1453427bc2937fceab9811bd" \
-     -d "client_secret=efbc9e1f2bcc4968c988ef5b839dd5a4" \
-     -d "redirect_uri=http://getkong.org/" \
-     -d "code=ad286cf6694d40aac06eff2797b7208d" --insecure
+curl -X POST \
+  --url "https://127.0.0.1:8443/oauth2/token" \
+  --header "Host: test.com" \
+  --data "grant_type=authorization_code" \
+  --data "client_id=318f98be1453427bc2937fceab9811bd" \
+  --data "client_secret=efbc9e1f2bcc4968c988ef5b839dd5a4" \
+  --data "redirect_uri=http://getkong.org/" \
+  --data "code=ad286cf6694d40aac06eff2797b7208d" \
+  --insecure
 ```

--- a/app.js
+++ b/app.js
@@ -28,7 +28,7 @@ function load_env_variable(name) {
 var PROVISION_KEY = load_env_variable("PROVISION_KEY");
 
 /*
-  Thie is the host for the service that OAuth2.0 applies to
+  This is the host for the service that OAuth2.0 applies to
 /*
 var SERVICE_HOST = load_env_variable("SERVICE_HOST")
 

--- a/app.js
+++ b/app.js
@@ -28,6 +28,11 @@ function load_env_variable(name) {
 var PROVISION_KEY = load_env_variable("PROVISION_KEY");
 
 /*
+  Thie is the host for the service that OAuth2.0 applies to
+/*
+var SERVICE_HOST = load_env_variable("SERVICE_HOST")
+
+/*
   URLs to Kong
 */
 var KONG_ADMIN = load_env_variable("KONG_ADMIN");
@@ -80,7 +85,10 @@ function authorize(client_id, response_type, scope, callback) {
   request({
     method: "POST",
     url: KONG_API + API_PATH + "/oauth2/authorize",
-	  form: { 
+    headers: {
+      Host: SERVICE_HOST
+    },
+    form: { 
       client_id: client_id, 
       response_type: response_type, 
       scope: scope, 


### PR DESCRIPTION
This also changes the curl commands to use the same notation as used in the docs seen on https://docs.konghq.com/0.14.x/getting-started/configuring-a-service/