### PR TITLE
fix the bug according to https://github.com/Kong/kong/issues/6016

### DIFF
--- a/app.js
+++ b/app.js
@@ -62,8 +62,7 @@ var LISTEN_PORT = process.env["LISTEN_PORT"] || 3000
 function get_application_name(client_id, callback) {
   request({
     method: "GET",
-    url: KONG_ADMIN + "/oauth2",
-    qs: { client_id: client_id }
+    url: KONG_ADMIN + "/oauth2/" + client_id
   }, function(error, response, body) {
     var application_name;
     if (client_id && !error) {


### PR DESCRIPTION
when create more than one client application, filter not work will result in http://127.0.0.1:3000/authorize?response_type=code&client_id=y7VRxfVplsB4Pw7CozovU2tucUNghIz0&scope=address can not success redirct to http://konghq.com/?code=ad286cf6694d40aac06eff2797b7208d